### PR TITLE
[visOptions/yExtent] display validation error when bounds are equal

### DIFF
--- a/src/plugins/kbn_vislib_vis_types/public/controls/__tests__/point_series_options.js
+++ b/src/plugins/kbn_vislib_vis_types/public/controls/__tests__/point_series_options.js
@@ -1,0 +1,79 @@
+import ngMock from 'ngMock';
+import $ from 'jquery';
+import expect from 'expect.js';
+
+describe('point series options', function () {
+  describe('Set Y-Axis Extents', function () {
+    let compile;
+
+    function isVisible($el) {
+      $el.appendTo('body');
+      const is = $el.is(':visible');
+      $el.remove();
+      return is;
+    }
+
+    beforeEach(ngMock.module('kibana'));
+    beforeEach(ngMock.inject(function ($compile, $rootScope, Private) {
+      const Vis = Private(require('ui/Vis'));
+      const indexPattern = Private(require('fixtures/stubbed_logstash_index_pattern'));
+
+      compile = function (min, max) {
+        const $el = $('<vis-editor-vis-options vis="vis">');
+        const $scope = $rootScope.$new();
+
+        $scope.vis = new Vis(indexPattern, {
+          type: 'line',
+          params: {
+            setYExtents: true,
+            yAxis: {
+              max: max,
+              min: min
+            },
+          },
+          aggs: [
+            {
+              type: 'count',
+              schema: 'metric',
+            },
+            {
+              type: 'date_histogram',
+              schema: 'segment',
+              params: {
+                field: '@timestamp',
+              }
+            }
+          ],
+        });
+
+        $compile($el)($scope);
+        $rootScope.$digest();
+
+        const $err = $el.findTestSubject('visOptionSetYExtents error');
+
+        return { $el, $err, $scope };
+      };
+    }));
+
+    context('min is less than max', function () {
+      it('hides the error message', function () {
+        const { $err } = compile(9, 10);
+        expect(isVisible($err)).to.be(false);
+      });
+    });
+
+    context('min is equal to max', function () {
+      it('shows the error message', function () {
+        const { $err } = compile(10, 10);
+        expect(isVisible($err)).to.be(true);
+      });
+    });
+
+    context('min is greater than max', function () {
+      it('shows the error message', function () {
+        const { $err } = compile(11, 10);
+        expect(isVisible($err)).to.be(true);
+      });
+    });
+  });
+});

--- a/src/plugins/kbn_vislib_vis_types/public/controls/point_series_options.html
+++ b/src/plugins/kbn_vislib_vis_types/public/controls/point_series_options.html
@@ -5,7 +5,7 @@
       Current time marker
     </label>
   </div>
-  <div class="vis-option-item">
+  <div class="vis-option-item" data-test-subj="visOptionSetYExtents">
     <label>
       <input type="checkbox" ng-model="vis.params.setYExtents">
       Set Y-Axis Extents
@@ -21,7 +21,7 @@
                ng-model="vis.params.yAxis.max"
                ng-required="vis.params.setYExtents">
       </label>
-      <div ng-show="vis.params.yAxis.min > vis.params.yAxis.max">
+      <div ng-show="vis.params.yAxis.min >= vis.params.yAxis.max" data-test-subj="error">
         <span class="text-danger">Min must not exceed max</span>
       </div>
       <label>


### PR DESCRIPTION
Fixes #1 